### PR TITLE
fixed: hack to `finish` event that it emits actually after finishing consumption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1197,11 +1197,6 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true
     },
-    "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
-    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -3839,10 +3834,19 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
-    "parallel-transform": {
-      "version": "github:piglovesyou/parallel-transform#1356867baa1840079215ae3518116690f00f096b",
+    "parallel-transform-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parallel-transform-stream/-/parallel-transform-stream-1.0.1.tgz",
+      "integrity": "sha1-QeyRa3FCLgbqlBcaxX7ZEV2udyE=",
       "requires": {
-        "cyclist": "0.2.2"
+        "cyclist": "1.0.1"
+      },
+      "dependencies": {
+        "cyclist": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+          "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+        }
       }
     },
     "parse-glob": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "is-stream": "^1.1.0",
     "lazy-promise": "^4.0.0",
-    "parallel-transform": "github:piglovesyou/parallel-transform",
+    "parallel-transform-stream": "^1.0.1",
     "pump": "^3.0.0",
     "stream-array": "^1.1.2"
   },

--- a/src/hole-transform.js
+++ b/src/hole-transform.js
@@ -1,0 +1,60 @@
+import ParallelTransform from 'parallel-transform-stream';
+import {Writable} from 'stream';
+
+const defaultWritableHighWaterMark = getDefaultWritableHighWaterMark();
+
+export default class HoleTransform extends ParallelTransform {
+  constructor(asyncFn, options) {
+
+    super({
+      maxParallel: defaultWritableHighWaterMark,
+      highWaterMark: defaultWritableHighWaterMark,
+      ...options,
+      objectMode: true,
+    });
+
+    // Ugly hack for ParallelTransform emitting `finish`
+    // when it **starts consuming last task**, not completes it.
+    // `pump` uses the event to call a callback afterward
+    // where we finish the whole streaming. See
+    // https://github.com/ubilabs/node-parallel-transform-stream/issues/2
+    this._finished = false;
+    this._consumingLength = 0;
+    this._asyncFn = asyncFn;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  _parallelTransform(data, enc, callback) {
+    this._consumingLength++;
+    const rv = this._asyncFn.call(this, data);
+    Promise.resolve(rv)
+        .then(resolved => {
+          callback(null, resolved);
+          this._consumingLength--;
+          if (this._finished && this._consumingLength === 0) {
+            setImmediate(() => {
+              return super.emit('finish');
+            });
+          }
+        });
+  }
+
+  emit(...args) {
+    const [type] = args;
+    if (type === 'finish') {
+      this._finished = true;
+      return;
+    }
+    return super.emit.apply(this, args);
+  }
+
+}
+
+function getDefaultWritableHighWaterMark() {
+  const w = new Writable({objectMode: true});
+  // Node v9.4.0 or higher only returns number 16
+  const rv = w.writableHighWaterMark || 16;
+  // $FlowFixMe https://github.com/facebook/flow/pull/5763
+  w.destroy();
+  return rv;
+}

--- a/test/main.js
+++ b/test/main.js
@@ -199,13 +199,13 @@ describe('Hole', function () {
 
   it('consumes large number of data', async function () {
     const expect = 10 * 1000;
-    let actual = null;
+    let actual = 0;
     const r = createReadable(expect);
     await holeWithStream(r)
         .pipe(async i => {
           await timeout(Math.random() * 10);
-          actual = i + 1;
-        }, {highWaterMark: 32});
+          actual++;
+        }, 32);
     assert.deepStrictEqual(actual, expect);
   });
 

--- a/test/main.js
+++ b/test/main.js
@@ -204,11 +204,8 @@ describe('Hole', function () {
     await holeWithStream(r)
         .pipe(async i => {
           await timeout(Math.random() * 10);
-          return i;
-        }, {highWaterMark: 32})
-        .pipe(i => {
           actual = i + 1;
-        });
+        }, {highWaterMark: 32});
     assert.deepStrictEqual(actual, expect);
   });
 


### PR DESCRIPTION
* HoleStream: Inherit parallel-transform-stream
  * that covers `finish` event disruption
* isLast is not necessary because of voidWriter